### PR TITLE
Improve Running Speed

### DIFF
--- a/src/main/java/com.ai/PolicyTester.java
+++ b/src/main/java/com.ai/PolicyTester.java
@@ -37,16 +37,16 @@ public class PolicyTester {
 
     public Result testPolicy(Policy policy, int numTests) {
         List<Integer> runData = new ArrayList<>();
-	boolean terminated = false;
+        boolean terminated = false;
 
         for (int i = 0; i < numTests; i++) {
-	    if (i == EARLY_STOP_TESTS && !terminated)
-		break;
+            if (i == EARLY_STOP_TESTS && !terminated)
+                break;
 
-	    int runLength = raceSimulator.runPolicy(racetrack.randomStartingPosition(), policy);
-	    if (!terminated) {
-		terminated = !raceSimulator.atIterationLimit(runLength);
-	    }
+            int runLength = raceSimulator.runPolicy(racetrack.randomStartingPosition(), policy);
+            if (!terminated) {
+                terminated = !raceSimulator.atIterationLimit(runLength);
+            }
             runData.add(runLength);
         }
         return new Result(runData);

--- a/src/main/java/com.ai/PolicyTester.java
+++ b/src/main/java/com.ai/PolicyTester.java
@@ -14,6 +14,7 @@ public class PolicyTester {
     private final int numTests;
 
     private static final int DEFAULT_NUM_TESTS = 20;
+    private static final int EARLY_STOP_TESTS = 10;
 
     public PolicyTester(Racetrack racetrack, CollisionModel collisionModel) {
         this(racetrack, collisionModel, DEFAULT_NUM_TESTS);
@@ -36,9 +37,17 @@ public class PolicyTester {
 
     public Result testPolicy(Policy policy, int numTests) {
         List<Integer> runData = new ArrayList<>();
+	boolean terminated = false;
 
         for (int i = 0; i < numTests; i++) {
-            runData.add(raceSimulator.runPolicy(racetrack.randomStartingPosition(), policy));
+	    if (i == EARLY_STOP_TESTS && !terminated)
+		break;
+
+	    int runLength = raceSimulator.runPolicy(racetrack.randomStartingPosition(), policy);
+	    if (!terminated) {
+		terminated = !raceSimulator.atIterationLimit(runLength);
+	    }
+            runData.add(runLength);
         }
         return new Result(runData);
     }

--- a/src/main/java/com.ai/PolicyTester.java
+++ b/src/main/java/com.ai/PolicyTester.java
@@ -40,8 +40,9 @@ public class PolicyTester {
         boolean terminated = false;
 
         for (int i = 0; i < numTests; i++) {
-            if (i == EARLY_STOP_TESTS && !terminated)
+            if (i == EARLY_STOP_TESTS && !terminated) {
                 break;
+            }
 
             int runLength = raceSimulator.runPolicy(racetrack.randomStartingPosition(), policy);
             if (!terminated) {

--- a/src/main/java/com.ai/alg/RacetrackLearner.java
+++ b/src/main/java/com.ai/alg/RacetrackLearner.java
@@ -4,6 +4,14 @@ import com.ai.Policy;
 import com.ai.Racetrack;
 import com.ai.sim.CollisionModel;
 
+/**
+ * A template for racetrack learners, which in general need a racetrack and collision model to operate on.
+ *
+ * Allows learners to be ran iteratively.
+ * After calling `next`, calling `getPolicy` and `getIterationCount` will indicate the learner's current policy
+ * and how many iterations have been performed respectively. `finished` allows for a learner to indicate
+ * when they are done learning.
+ */
 public abstract class RacetrackLearner {
     protected Racetrack racetrack;
     protected CollisionModel collisionModel;

--- a/src/main/java/com.ai/alg/ValueIteration.java
+++ b/src/main/java/com.ai/alg/ValueIteration.java
@@ -25,7 +25,7 @@ public class ValueIteration extends RacetrackLearner {
     private Policy policy = new ValueIterationPolicy();
 
     private static final double GAMMA = 0.7;
-    private static final double EPSILON = 0.01;
+    private static final double EPSILON = 0.0001;
 
     public ValueIteration(Racetrack racetrack, CollisionModel collisionModel) {
         super(racetrack, collisionModel);

--- a/src/main/java/com.ai/sim/RaceSimulator.java
+++ b/src/main/java/com.ai/sim/RaceSimulator.java
@@ -31,6 +31,6 @@ public class RaceSimulator {
     }
 
     public boolean atIterationLimit(int iterationCount) {
-	return iterationCount >= iterationLimit;
+        return iterationCount >= iterationLimit;
     }
 }

--- a/src/main/java/com.ai/sim/RaceSimulator.java
+++ b/src/main/java/com.ai/sim/RaceSimulator.java
@@ -12,7 +12,7 @@ public class RaceSimulator {
 
     public RaceSimulator(Racetrack racetrack, CollisionModel collisionModel) {
         this.actionSimulator = new MDPActionSimulator(new RacetrackMDP(racetrack, collisionModel));
-        this.iterationLimit = racetrack.getWidth() * racetrack.getHeight() * 121 * 2;
+        this.iterationLimit = racetrack.getWidth() * racetrack.getHeight() * 121;
     }
 
     public Integer runPolicy(Position start, Policy policy) {
@@ -28,5 +28,9 @@ public class RaceSimulator {
         if (currentState == null)
             return cost;
         return iterationLimit;
+    }
+
+    public boolean atIterationLimit(int iterationCount) {
+	return iterationCount >= iterationLimit;
     }
 }


### PR DESCRIPTION
I observed that most of the testing time for value iteration comes from the time to reach the iteration limit. So I've made a few changes that allow us to test larger numbers of tests and overall speeds everything up. Running `java -jar build/libs/racetrack_ai-0.0.0-SNAPSHOT.jar -racetrack r_track -model stop -learner value-iteration -num-tests 1000` isn't painful at all with these changes.

 
#### Changes:
- Make epsilon smaller (makes value iteration finish on `r_track`)
- Stop testing a policy if it hasn't terminated once after a certain number of tests (currently set to `10`)
- Reduce the iteration limit for a policy by half. If something needs to do more than perform every action in every square, it's still very clearly doing something wrong, even if it might terminate. Getting rid of the `*2` makes it twice as fast, and I think this iteration limit is still lenient.

---
#### Please Review: @sagersmith8 @JWhitney406 